### PR TITLE
fix to stop watch fail after first run

### DIFF
--- a/src/registries/server.js
+++ b/src/registries/server.js
@@ -39,8 +39,9 @@ function ServerRegistry(config = {}) {
   /**
    * reloads the application
    */
-  this.reload = () => {
+  this.reload = cb => {
     server.reload();
+    cb();
   };
 
   /**


### PR DESCRIPTION
Gulp watch fails after first run. this is a fix for that. Reference is as follows.
https://github.com/gulpjs/gulp/issues/1626#issuecomment-231020035
